### PR TITLE
Fix unallowed metric labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function zwaveLabel(label) {
         .toLowerCase()
         .replaceAll(' ', '_')
         .replaceAll('₂', '2') // special case for co2
-        .replaceAll(/[,.!?()]/ig, '')
+        .replaceAll(/[^a-zA-Z0-9_]/ig, '') // Remove all non-allowed letters (see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)
 }
 
 class ZwavejsProm {


### PR DESCRIPTION
This patch fixes a problem where previously some zwave metrics could contained non-allowed characters. This patch changes the behavior to remove all non-allowed characters.

Previously having a zwave device with property names containing characters such has `-` would crash zwave2mqtt with an exception like this:
```
Error: Invalid metric name
    at new Metric (/usr/src/app/plugins/zwavejs-prom/node_modules/prom-client/lib/metric.js:36:10)
    at new Gauge (/usr/src/app/plugins/zwavejs-prom/node_modules/prom-client/lib/gauge.js:19:1)
    at /usr/src/app/plugins/zwavejs-prom/index.js:192:13
    at getOrDefault (/usr/src/app/plugins/zwavejs-prom/index.js:40:13)
    at ZwavejsProm.onValueChanged (/usr/src/app/plugins/zwavejs-prom/index.js:191:21)
    at ZwaveClient.emit (node:events:406:35)
    at ZwaveClient.emit (node:domain:470:12)
    at ZwaveClient.emitValueChanged (/usr/src/app/server/lib/ZwaveClient.js:787:14)
    at ZwaveClient._addValue (/usr/src/app/server/lib/ZwaveClient.js:2519:22)
    at ZwaveClient._onNodeReady (/usr/src/app/server/lib/ZwaveClient.js:2021:18)
```
